### PR TITLE
🐛 Fix: 후기 신고 3회 이상 당한 유저 집중관리 회원으로 변경하는 로직 이동 / 후기 가리기 로직 추가

### DIFF
--- a/src/main/java/com/poppin/poppinserver/controller/ReportController.java
+++ b/src/main/java/com/poppin/poppinserver/controller/ReportController.java
@@ -18,11 +18,11 @@ public class ReportController {
 
     private final ReportService reportService;
 
-    // 관리자 페이지 - 후기 신고 - 후기 숨기기
-    @PostMapping("/hide-review")
-    public ResponseDto<?> hideReview(@UserId Long userId, @RequestBody ReviewInfoDto reviewInfoDto){
-        return ResponseDto.ok(reportService.hideReview(userId, reviewInfoDto));
-    }
+//    // 관리자 페이지 - 후기 신고 - 후기 숨기기
+//    @PostMapping("/hide-review")
+//    public ResponseDto<?> hideReview(@UserId Long userId, @RequestBody ReviewInfoDto reviewInfoDto){
+//        return ResponseDto.ok(reportService.hideReview(userId, reviewInfoDto));
+//    }
 
     /* 유저 후기 신고 */
     @PostMapping("/review/{reviewId}")

--- a/src/main/java/com/poppin/poppinserver/domain/Review.java
+++ b/src/main/java/com/poppin/poppinserver/domain/Review.java
@@ -66,5 +66,9 @@ public class Review {
 
     public void addRecommendCnt(){this.recommendCnt += 1;} // 추천 버튼 클릭시
     public void updateReviewUrl(String imageUrl){this.imageUrl = imageUrl;}
-    public void updateReviewVisible(){if (this.getIsVisible()) this.isVisible = false;}
+    public void updateReviewInvisible() {
+        if (this.getIsVisible()) {
+            this.isVisible = false;
+        }
+    }
 }

--- a/src/main/java/com/poppin/poppinserver/service/ReportService.java
+++ b/src/main/java/com/poppin/poppinserver/service/ReportService.java
@@ -25,22 +25,21 @@ public class ReportService {
     private final ReportPopupRepository reportPopupRepository;
     private final PopupRepository popupRepository;
 
-    public Review hideReview(Long userId, ReviewInfoDto reviewInfoDto){
+//    public Review hideReview(Long userId, ReviewInfoDto reviewInfoDto){
+//
+//
+//        /*관리자 여부 체크 메서드도 필요*/
+//        /**/
+//
+//        Review review = reviewRepository.findById(reviewInfoDto.reviewId())
+//                .orElseThrow(() -> new CommonException(ErrorCode.NOT_FOUND_REVIEW));
+//
+//        review.updateReviewInvisible();
+//
+//        return reviewRepository.save(review);
+//
+//    }
 
-
-        /*관리자 여부 체크 메서드도 필요*/
-        /**/
-
-        Review review = reviewRepository.findById(reviewInfoDto.reviewId())
-                .orElseThrow(() -> new CommonException(ErrorCode.NOT_FOUND_REVIEW));
-
-        review.updateReviewVisible();
-
-        return reviewRepository.save(review);
-
-    }
-
-    @Transactional
     public void createReviewReport(Long userId, Long reviewId, CreateReviewReportDto createReviewReportDto){
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CommonException(ErrorCode.NOT_FOUND_USER));
@@ -54,14 +53,14 @@ public class ReportService {
                 .isExecuted(false)
                 .build();
 
-        User reviewAuthor = review.getUser();
-        reviewAuthor.addReportCnt();
-
-        if (reviewAuthor.getReportedCnt() >= 3){
-            reviewAuthor.requiresSpecialCare();
-        }
-
-        userRepository.save(reviewAuthor);
+//        User reviewAuthor = review.getUser();
+//        reviewAuthor.addReportCnt();
+//
+//        if (reviewAuthor.getReportedCnt() >= 3){
+//            reviewAuthor.requiresSpecialCare();
+//        }
+//
+//         userRepository.save(reviewAuthor);
         reportReviewRepository.save(reportReview);
     }
 


### PR DESCRIPTION
- 유저 후기 신고가 관리자에 의해 후기가 가려질 경우, reported count가 증가한다.
- 유저 후기 신고가 관리자에 의해 3회 이상 처리될 경우 유저는 집중관리 회원이 된다.