### PR TITLE
✨ Feat: 중복 계정 로그인 & 회원가입 Exception 추가

### DIFF
--- a/src/main/java/com/poppin/poppinserver/exception/ErrorCode.java
+++ b/src/main/java/com/poppin/poppinserver/exception/ErrorCode.java
@@ -34,6 +34,7 @@ public enum ErrorCode {
     DUPLICATED_TOKEN("40023", HttpStatus.BAD_REQUEST, "이미 알림 동의를 하셨습니다."),
     DELETED_USER_ERROR("40024", HttpStatus.BAD_REQUEST, "탈퇴한 유저는 30일 동안 재가입할 수 없습니다."),
     REVIEW_RECOMMEND_ERROR("40025", HttpStatus.BAD_REQUEST, "자신의 후기에 추천 할 수 없습니다."),
+    DUPLICATED_SOCIAL_ID("40026", HttpStatus.BAD_REQUEST, "해당 이메일로 가입된 계정이 존재합니다."),
 
     // Unauthorized Error
     FAILURE_LOGIN("40100", HttpStatus.UNAUTHORIZED, "로그인에 실패했습니다."),

--- a/src/main/java/com/poppin/poppinserver/service/AuthService.java
+++ b/src/main/java/com/poppin/poppinserver/service/AuthService.java
@@ -115,6 +115,10 @@ public class AuthService {
         if (user.isPresent() && user.get().getIsDeleted()) {
             throw new CommonException(ErrorCode.DELETED_USER_ERROR);
         }
+        // 이미 가입된 계정이 있는지 확인
+        if (user.isPresent() && !user.get().getProvider().equals(provider)) {
+            throw new CommonException(ErrorCode.DUPLICATED_SOCIAL_ID);
+        }
         // USER 권한 + 이메일 정보가 DB에 존재 -> 팝핀 토큰 발급 및 로그인 상태 변경
         if (user.isPresent() && user.get().getProvider().equals(provider)) {
             JwtTokenDto jwtTokenDto = jwtUtil.generateToken(user.get().getId(), EUserRole.USER);


### PR DESCRIPTION
- 이메일과 USER ROLE을 가진 회원이 존재하고, 요청한 provider와 DB에 있는 provider가 다를 경우 이미 가입된 계정이 존재한다는 Exception을 터뜨립니다.