### PR TITLE
🐛 Fix: 개발계 build.gradle 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,7 @@ dependencies {
 	implementation 'com.github.fernandospr:javapns-jdk16:2.4.0' // IOS >= 10
 
 	// OpenFeign
-	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+	 implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 
 	// ETC
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
@@ -84,8 +84,12 @@ tasks.withType(JavaCompile) {
 	options.encoding = 'UTF-8'
 }
 
+bootJar {
+	archiveFileName.set "poppin-server-0.0.1-SNAPSHOT.jar"
+}
+
 jar {
-	archiveFileName.set('poppin-server-0.0.1-SNAPSHOT.jar')
+	enabled = false
 }
 
 dependencyManagement {


### PR DESCRIPTION
jar {
	archiveFileName.set('poppin-server-0.0.1-SNAPSHOT.jar')
}

위와 같은 코드로 인해 plain.jar 파일이 .jar 파일명으로 생성되어 java -jar로 실행 시 no main manifest attribute 에러가 발생하여 개발계에 배포를 하지 못했었습니다. (로컬에서는 잘 작동되었음.)

그래서 실행되도록 수정했습니다.